### PR TITLE
fix: properly upload files to S3 using multipart presigned POST

### DIFF
--- a/src/perplexity_webui_scraper/core.py
+++ b/src/perplexity_webui_scraper/core.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from curl_cffi import CurlMime
+from curl_cffi.requests import Session
 from orjson import JSONDecodeError, loads
 
 
@@ -379,54 +381,54 @@ class Conversation:
             response = self._http.post(ENDPOINT_UPLOAD, json=json_data)
             response_data = response.json()
             result = response_data.get("results", {}).get(file_uuid, {})
-            
+
             s3_bucket_url = result.get("s3_bucket_url")
             s3_object_url = result.get("s3_object_url")
             fields = result.get("fields", {})
 
             if not s3_object_url:
                 raise FileUploadError(file_info.path, "No upload URL returned")
-            
+
             if not s3_bucket_url or not fields:
                 raise FileUploadError(file_info.path, "Missing S3 upload credentials")
 
             # Upload the file to S3 using presigned POST
             file_path = Path(file_info.path)
+
             with file_path.open("rb") as f:
                 file_content = f.read()
-            
+
             # Build multipart form data using CurlMime
             # For S3 presigned POST, form fields must come before the file
-            from curl_cffi import CurlMime
-            
-            mp = CurlMime()
-            # Add all presigned form fields first
+            mime = CurlMime()
+
             for field_name, field_value in fields.items():
-                mp.addpart(name=field_name, data=field_value)
-            # Add the file last (required for S3 presigned POST)
-            mp.addpart(
+                mime.addpart(name=field_name, data=field_value)
+
+            mime.addpart(
                 name="file",
                 content_type=file_info.mimetype,
                 filename=file_path.name,
                 data=file_content,
             )
-            
-            from curl_cffi.requests import Session
-            upload_session = Session()
-            upload_response = upload_session.post(s3_bucket_url, multipart=mp)
-            mp.close()
-            
+
+            # S3 requires a clean session
+            with Session() as s3_session:
+                upload_response = s3_session.post(s3_bucket_url, multipart=mime)
+
+            mime.close()
+
             if upload_response.status_code not in (200, 201, 204):
                 raise FileUploadError(
-                    file_info.path, 
-                    f"S3 upload failed with status {upload_response.status_code}: {upload_response.text}"
+                    file_info.path,
+                    f"S3 upload failed with status {upload_response.status_code}: {upload_response.text}",
                 )
 
             return s3_object_url
         except FileUploadError as error:
             raise error
-        except Exception as e:
-            raise FileUploadError(file_info.path, str(e)) from e
+        except Exception as error:
+            raise FileUploadError(file_info.path, str(error)) from error
 
     def _build_payload(
         self,
@@ -535,10 +537,10 @@ class Conversation:
 
         try:
             json_data = loads(data["text"])
-        except KeyError as e:
-            raise ValueError("Missing 'text' field in data") from e
-        except JSONDecodeError as e:
-            raise ValueError("Invalid JSON in 'text' field") from e
+        except KeyError as error:
+            raise ValueError("Missing 'text' field in data") from error
+        except JSONDecodeError as error:
+            raise ValueError("Invalid JSON in 'text' field") from error
 
         answer_data: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary

- Fixed file upload functionality by implementing proper S3 multipart upload
- Files are now actually uploaded to S3 before being used in conversations

## Problem

The `_upload_file` method in `core.py` was only retrieving a presigned S3 upload URL from Perplexity's API but never actually uploading the file content to S3. This caused images to never be sent to the AI model.

## Solution

Perplexity's upload API returns:
- `s3_bucket_url`: The S3 bucket endpoint for the POST
- `s3_object_url`: The final URL where the file will be accessible
- `fields`: Presigned form fields required for the S3 POST

The fix:
1. Extract all three components from the API response
2. Use `CurlMime` to build multipart form data
3. Add all presigned fields first (required by S3)
4. Add the file content last
5. POST the multipart data to S3
6. Return `s3_object_url` only after successful upload
7. Add error handling for S3 upload failures

## Testing

Verified fix works by running a test script that uploads an image and asks the model to describe it. The model now correctly recognizes and describes the uploaded image content.