### PR TITLE
fix: add max_init_query_length to prevent HTTP 414 on long queries

### DIFF
--- a/src/perplexity_webui_scraper/config.py
+++ b/src/perplexity_webui_scraper/config.py
@@ -44,5 +44,6 @@ class ClientConfig(BaseModel):
     retry_jitter: float = 0.5
     requests_per_second: float = 0.5
     rotate_fingerprint: bool = True
+    max_init_query_length: int = 2000
     logging_level: LogLevel = LogLevel.DISABLED
     log_file: str | PathLike[str] | None = None

--- a/src/perplexity_webui_scraper/core.py
+++ b/src/perplexity_webui_scraper/core.py
@@ -63,6 +63,7 @@ class Perplexity:
             retry_jitter=cfg.retry_jitter,
             requests_per_second=cfg.requests_per_second,
             rotate_fingerprint=cfg.rotate_fingerprint,
+            max_init_query_length=cfg.max_init_query_length,
         )
 
         logger.info("Perplexity client initialized")

--- a/src/perplexity_webui_scraper/http.py
+++ b/src/perplexity_webui_scraper/http.py
@@ -30,6 +30,7 @@ class HTTPClient:
 
     __slots__ = (
         "_impersonate",
+        "_max_init_query_length",
         "_rate_limiter",
         "_retry_config",
         "_rotate_fingerprint",
@@ -49,11 +50,13 @@ class HTTPClient:
         retry_jitter: float = 0.5,
         requests_per_second: float = 0.5,
         rotate_fingerprint: bool = True,
+        max_init_query_length: int = 2000,
     ) -> None:
         self._session_token = session_token
         self._timeout = timeout
         self._impersonate = impersonate
         self._rotate_fingerprint = rotate_fingerprint
+        self._max_init_query_length = max_init_query_length
 
         self._retry_config = RetryConfig(
             max_retries=max_retries,
@@ -219,7 +222,16 @@ class HTTPClient:
             response.close()
 
     def init_search(self, query: str) -> None:
-        """Initialize a search session (required before prompts)."""
+        """Initialize a search session (required before prompts).
+
+        The query is sent as a GET parameter. Very long queries can exceed
+        server URI limits (HTTP 414). When ``max_init_query_length`` is set
+        (default 2000), the query is truncated to stay within safe limits.
+        Set to ``0`` to disable truncation.
+        """
+
+        if self._max_init_query_length and len(query) > self._max_init_query_length:
+            query = query[: self._max_init_query_length]
 
         self.get(ENDPOINT_SEARCH_INIT, params={"q": query})
 


### PR DESCRIPTION
## Problem

`init_search()` sends the full query string as a GET parameter (`?q=...`) to `/search/new`. For long prompts — common in multi-turn AI workflows or when attaching context — this exceeds server URI limits and returns **HTTP 414 (URI Too Long)**.

The warm-up GET only primes the session; the full query is delivered separately via the POST payload to `/ask`. Truncating the warm-up query has no effect on the actual prompt sent to the model.

## Fix

Add a configurable `max_init_query_length` field to `ClientConfig` (default **2000** characters). When the query exceeds this limit, it is truncated before the warm-up GET request.

### Changes

| File | Change |
|------|--------|
| `config.py` | Add `max_init_query_length: int = 2000` to `ClientConfig` |
| `http.py` | Add `_max_init_query_length` slot, store config value, truncate in `init_search()` |
| `core.py` | Thread config value from `Perplexity` to `HTTPClient` |

### Usage

```python
from perplexity_webui_scraper import Perplexity
from perplexity_webui_scraper.config import ClientConfig

# Default: truncates init_search query to 2000 chars (prevents 414)
client = Perplexity(token)

# Custom limit
client = Perplexity(token, config=ClientConfig(max_init_query_length=500))

# Disable truncation (original behavior)
client = Perplexity(token, config=ClientConfig(max_init_query_length=0))
```

## Backward Compatibility

- Default value of 2000 is well within safe URI limits while preserving meaningful warm-up context
- Setting `max_init_query_length=0` restores the original untruncated behavior
- No changes to the POST payload or any other API interaction


Made with [Cursor](https://cursor.com)